### PR TITLE
Fix some issues with v0.17

### DIFF
--- a/src/components.nim
+++ b/src/components.nim
@@ -79,8 +79,8 @@ proc stateDecl(n: NimNode; names: TableRef[string, bool]; decl: NimNode) =
       for i in 0 .. c.len-3:
         let v = $c[i]
         let sv = toState v
-        decl.add quote do:
-          var `sv` = newStateDict[`usedType`]()
+        decl.add(quote do:
+          var `sv` = newStateDict[`usedType`]())
         if val.kind != nnkEmpty:
           decl.add newTree(nnkAsgn, newDotExpr(sv, newIdentNode"defaultValue"),
                            val)

--- a/src/karaxdsl.nim
+++ b/src/karaxdsl.nim
@@ -101,20 +101,22 @@ proc tcall2(n, tmpContext: NimNode): NimNode =
     result = n
 
 macro buildHtml*(tag, children: untyped): VNode =
-  expectKind children, nnkDo
+  let kids = newProc(procType=nnkDo, body=children)
+  expectKind kids, nnkDo
   var call: NimNode
   if tag.kind in nnkCallKinds:
     call = tag
   else:
     call = newCall(tag)
-  call.add body(children)
+  call.add body(kids)
   result = tcall2(call, nil)
   when defined(debugKaraxDsl):
     echo repr result
 
 macro buildHtml*(children: untyped): VNode =
-  expectKind children, nnkDo
-  result = tcall2(body(children), nil)
+  let kids = newProc(procType=nnkDo, body=children)
+  expectKind kids, nnkDo
+  result = tcall2(body(kids), nil)
   when defined(debugKaraxDsl):
     echo repr result
 


### PR DESCRIPTION
The change to components fixes `do:` ambiguity, the change to karaxdsl  fixes an `Expected a node of kind nnkDo, got nnkStmtList` error in buildHtml