### PR TITLE
Introduce notion of karax instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 nimcache/
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,58 @@
+language: node_js
+env:
+  - BRANCH=master
+  - BRANCH=devel
+matrix:
+  allow_failures:
+    - env: BRANCH=devel
+  fast_finish: true
+install:
+  - |
+    if [ ! -x nim-$BRANCH/bin/nim ]; then
+      git clone -b $BRANCH --depth 1 git://github.com/nim-lang/nim nim-$BRANCH/
+      cd nim-$BRANCH
+      git clone --depth 1 git://github.com/nim-lang/csources csources/
+      cd csources
+      sh build.sh
+      cd ..
+      rm -rf csources
+      bin/nim c koch
+      ./koch boot -d:release
+      ./koch nimble
+    else
+      cd nim-$BRANCH
+      git fetch origin
+      if ! git merge FETCH_HEAD | grep "Already up-to-date"; then
+        bin/nim c koch
+        ./koch boot -d:release
+        ./koch nimble
+      fi
+    fi
+    cd ..
+before_script:
+    - |
+      echo "Running with Nim from: nim-$BRANCH"
+      ls -l "nim-$BRANCH/bin"
+      NIMABSPATH=`readlink -f nim-$BRANCH/bin`
+      export PATH="${NIMABSPATH}${PATH:+:$PATH}"
+      echo "Path: $PATH"
+      nimble install
+script:
+    - |
+      cd "$TRAVIS_BUILD_DIR/examples/scrollapp"
+      nim js scrollapp.nim
+    - |
+      cd "$TRAVIS_BUILD_DIR/examples/mediaplayer"
+      nim js playerapp.nim
+    - |
+      cd "$TRAVIS_BUILD_DIR/examples/todoapp"
+      nim js todoapp.nim
+    - |
+      cd "$TRAVIS_BUILD_DIR/tests"
+      nim js diffDomTests.nim
+cache:
+  directories:
+    - nim-master
+    - nim-devel
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,9 @@ script:
       cd "$TRAVIS_BUILD_DIR/examples/todoapp"
       nim js todoapp.nim
     - |
+      cd "$TRAVIS_BUILD_DIR/experiments"
+      nim js ajaxtest.nim
+    - |
       cd "$TRAVIS_BUILD_DIR/tests"
       nim js diffDomTests.nim
 cache:

--- a/examples/mediaplayer/mediaplayer.nim
+++ b/examples/mediaplayer/mediaplayer.nim
@@ -12,7 +12,7 @@ proc play(n: Node) {.importcpp.}
 proc pause(n: Node) {.importcpp.}
 proc `width=`(n: Node, w: int) {.importcpp: "#.width = #".}
 
-proc mplayer*(id, resource: cstring): VNode {.component.} =
+proc mplayer*(karax: KaraxInstance, id, resource: cstring): VNode =
   proc handler(ev: Event; n: VNode) =
     let myVideo = document.getElementById(id)
     case n.key
@@ -26,7 +26,7 @@ proc mplayer*(id, resource: cstring): VNode {.component.} =
     of Normal: myVideo.width = 420
     else: discard
 
-  result = buildHtml(tdiv):
+  result = karax.buildHtml(tdiv):
     button(onclick=handler, key=Play):
       text "Play/Pause"
     button(onclick=handler, key=Big):

--- a/examples/mediaplayer/playerapp.nim
+++ b/examples/mediaplayer/playerapp.nim
@@ -1,21 +1,24 @@
 ## Example app that shows how to write and embed a custom component.
 
 include karaxprelude
-import mediaplayer
+import mediaplayer, kdom
+
+var karax: KaraxInstance
 
 const url = "https://www.w3schools.com/html/mov_bbb.mp4"
 
 proc createDom(): VNode =
-  result = buildHtml(table):
+  result = karax.buildHtml(table):
     tr:
       td:
-        mplayer("vid1", url)
+        mplayer(karax, "vid1", url)
       td:
-        mplayer("vid2", url)
+        mplayer(karax, "vid2", url)
     tr:
       td:
-        mplayer("vid3", url)
+        mplayer(karax, "vid3", url)
       td:
-        mplayer("vid4", url)
+        mplayer(karax, "vid4", url)
 
-setRenderer createDom
+window.onload = proc(ev: Event) =
+  karax = initKarax(createDom)

--- a/examples/scrollapp/scrollapp.nim
+++ b/examples/scrollapp/scrollapp.nim
@@ -3,6 +3,8 @@
 include karaxprelude
 import jstrutils, kdom, vstyles
 
+var karax: KaraxInstance
+
 var entries: seq[cstring] = @[]
 for i in 1..500:
   entries.add(cstring("Entry ") & &i)
@@ -15,11 +17,15 @@ proc scrollEvent(ev: Event; n: VNode) =
       entries.add(cstring("Loaded Entry ") & &i)
 
 proc createDom(): VNode =
-  result = buildHtml():
-    tdiv(onscroll=scrollEvent, style=style(
-        (StyleAttr.height, cstring"400px"), (StyleAttr.overflow, cstring"scroll"))):
+  let scrollStyle = style(
+    (StyleAttr.height, cstring"400px"),
+    (StyleAttr.overflow, cstring"scroll"),
+  )
+  result = karax.buildHtml:
+    tdiv(onscroll=scrollEvent, style=scrollStyle):
       for x in entries:
         tdiv:
           text x
 
-setRenderer createDom
+window.onload = proc(ev: Event) =
+  karax = initKarax(createDom)

--- a/experiments/ajaxtest.nim
+++ b/experiments/ajaxtest.nim
@@ -1,6 +1,11 @@
-import kdom, kajax
+import vdom, kdom, kajax, karax as karax_module
 
 proc cb(httpStatus: int, response: cstring) =
   echo "Worked!"
 
-ajaxGet("https://httpbin.org/get", @[], cb)
+proc createDom(): VNode =
+  nil
+
+var karax = initKarax(createDom)
+
+karax.ajaxGet("https://httpbin.org/get", @[], cb)

--- a/src/kajax.nim
+++ b/src/kajax.nim
@@ -3,14 +3,14 @@
 ## This module implements support for `ajax`:idx: socket
 ## handling.
 
-import karax
+import karax as karax_module
 
-proc ajax(meth, url: cstring; headers: openarray[(cstring, cstring)];
+proc ajax(karax: KaraxInstance; meth, url: cstring; headers: openarray[(cstring, cstring)];
           data: cstring;
           cont: proc (httpStatus: int; response: cstring)) =
   proc contWrapper(httpStatus: int; response: cstring) =
     cont(httpStatus, response)
-    redraw()
+    karax.redraw()
 
   type
     HttpRequest {.importc.} = ref object
@@ -37,14 +37,14 @@ proc ajax(meth, url: cstring; headers: openarray[(cstring, cstring)];
         contWrapper(this.status, this.statusText)
   ajax.send(data)
 
-proc ajaxPost*(url: cstring; headers: openarray[(cstring, cstring)];
+proc ajaxPost*(karax: KaraxInstance; url: cstring; headers: openarray[(cstring, cstring)];
           data: cstring;
           cont: proc (httpStatus: int, response: cstring)) =
-  ajax("POST", url, headers, data, cont)
+  karax.ajax("POST", url, headers, data, cont)
 
-proc ajaxGet*(url: cstring; headers: openarray[(cstring, cstring)];
+proc ajaxGet*(karax: KaraxInstance; url: cstring; headers: openarray[(cstring, cstring)];
           cont: proc (httpStatus: int, response: cstring)) =
-  ajax("GET", url, headers, nil, cont)
+  karax.ajax("GET", url, headers, nil, cont)
 
 proc toJson*[T](data: T): cstring {.importc: "JSON.stringify".}
 proc fromJson*[T](blob: cstring): T {.importc: "JSON.parse".}

--- a/src/karaxprelude.nim
+++ b/src/karaxprelude.nim
@@ -1,3 +1,4 @@
 ## Include file that contains the common imports for the Karax framework.
 
-import karax, karaxdsl, vdom, components
+import karaxdsl, vdom, components
+import karax as karax_module

--- a/tests/diffDomTests.nim
+++ b/tests/diffDomTests.nim
@@ -1,7 +1,8 @@
 
-import kdom, vdom, times, karax, karaxdsl, jdict, jstrutils, parseutils, sequtils
+import kdom, vdom, times, karax as karax_module, karaxdsl, jdict, jstrutils, parseutils, sequtils
 
 var
+    karax: KaraxInstance
     entries: seq[cstring]
     results: seq[cstring]
     timeout: Timeout
@@ -9,7 +10,7 @@ var
 proc reset() =
     results.add cstring"reset started"
     entries = @[cstring("0"), cstring("1"), cstring("2"), cstring("3"), cstring("4"), cstring("5") ]
-    redraw()
+    karax.redraw()
     results.add cstring"reset finished"
 
 proc checkOrder(order : seq[int]): bool =
@@ -35,7 +36,7 @@ proc test1() =
     results.add cstring"test1 started"
     entries = @[cstring("0"), cstring("1"), cstring("2"), cstring("3"), cstring("4"), cstring("5") ]
     entries.insert(cstring("7"), 5)
-    redraw()
+    karax.redraw()
     timeout = setTimeout(check1, 20)
 
 proc check2() =
@@ -51,7 +52,7 @@ proc test2() =
     entries = @[cstring("0"), cstring("1"), cstring("2"), cstring("3"), cstring("4"), cstring("5") ]
     entries.insert(cstring("7"), 5)
     entries.insert(cstring("8"), 0)
-    redraw()
+    karax.redraw()
     timeout = setTimeout(check2, 20)
 
 proc check3() =
@@ -65,7 +66,7 @@ proc check3() =
 proc test3() =
     results.add cstring"test3 started"
     entries = @[cstring("2"), cstring("3"), cstring("4"), cstring("1") ]
-    redraw()
+    karax.redraw()
     timeout = setTimeout(check3, 20)
 
 proc check4() =
@@ -79,7 +80,7 @@ proc check4() =
 proc test4() =
     results.add cstring"test4 started"
     entries = @[cstring("5"), cstring("6"), cstring("7"), cstring("8") ]
-    redraw()
+    karax.redraw()
     timeout = setTimeout(check4, 20)
 
 proc check5() =
@@ -93,7 +94,7 @@ proc check5() =
 proc test5() =
     results.add cstring"test5 started"
     entries = @[cstring("0"), cstring("1"), cstring("3"), cstring("5"), cstring("4"), cstring("5") ]
-    redraw()
+    karax.redraw()
     timeout = setTimeout(check5, 20)
 
 proc check6() =
@@ -107,7 +108,7 @@ proc check6() =
 proc test6() =
     results.add cstring"test6 started"
     entries = @[]
-    redraw()
+    karax.redraw()
     timeout = setTimeout(check6, 20)
 
 proc check7() =
@@ -116,30 +117,32 @@ proc check7() =
         results.add cstring"test7 - OK"
     else:
         results.add cstring"test7 - FAIL"
-    redraw()
+    karax.redraw()
 
 # result: 2
 proc test7() =
     results.add cstring"test7 started"
     entries = @[cstring("2")]
-    redraw()
+    karax.redraw()
     timeout = setTimeout(check7, 20)
 
 proc createEntry(id: int): VNode =
-  result = buildHtml():
+  result = karax.buildHtml():
     button(id="" & $id):
         text $id
 
 proc createDom(): VNode =
-    result = buildHtml(tdiv()):
+    result = karax.buildHtml(tdiv()):
         ul(id="ul"):
             for e in entries:
-                createEntry(parseInt(e))
+                createEntry(kdom.parseInt(e))
         for r in results:
             tdiv:
                 text r
 
 proc onload() =
+    karax = initKarax(createDom)
+
     for i in 0..5: # 0_000:
         entries.add(cstring($i))
 
@@ -179,5 +182,6 @@ proc onload() =
 
     timeout = setTimeout(test7, t)
 
-onload()
-setRenderer createDom
+
+window.onload = proc(ev: Event) =
+    onload()


### PR DESCRIPTION
After thinking about #9 a bit more, I think a proper solution would require to avoid having single/global state. The PR is only a draft how the design could look like to avoid global state, and introduce the notion of a Karax instance. 

This would allow to run multiple Karax instances, which can be useful for projects which want to migrate to Karax, but can't introduce on the top/root level. To start small, Karax could be introduced just in certain parts in the DOM.

Notes:
- I have only ported the scrollapp as an example.
- I did not pull the "focus" state into the Karax state, because it is inherently global.

What do you think about the idea? 