### PR TITLE
Enable list transitions

### DIFF
--- a/src/karax.nim
+++ b/src/karax.nim
@@ -117,6 +117,7 @@ proc same(n: VNode, e: Node): bool =
 var
   dorender: proc (): VNode {.closure.}
   currentTree: VNode
+  postRenderCallback: proc ()
 
 proc replaceById(id: cstring; newTree: Node) =
   let x = document.getElementById(id)
@@ -279,6 +280,10 @@ proc dodraw() =
       updateDirtyElements(nil, olddom, newtree)
       someDirty = false
     currentTree = newtree
+
+  if not postRenderCallback.isNil:
+    postRenderCallback()
+
   # now that it's part of the DOM, give it the focus:
   if toFocus != nil:
     toFocus.focus()
@@ -299,9 +304,10 @@ proc redraw*() =
 proc init(ev: Event) =
   reqFrame(dodraw)
 
-proc setRenderer*(renderer: proc (): VNode) =
+proc setRenderer*(renderer: proc (): VNode, clientPostRenderCallback: proc () = nil) =
   dorender = renderer
   window.onload = init
+  postRenderCallback = clientPostRenderCallback
 
 proc addEventHandler*(n: VNode; k: EventKind; action: EventHandler) =
   ## Implements the foundation of Karax's event management.

--- a/src/kdom.nim
+++ b/src/kdom.nim
@@ -273,6 +273,7 @@ type
     textDecoration*: cstring
     textIndent*: cstring
     textTransform*: cstring
+    transform*: cstring
     top*: cstring
     verticalAlign*: cstring
     visibility*: cstring
@@ -567,7 +568,7 @@ proc getElementsByClass*(n: Node; name: cstring): seq[Node] {.
 
 type
   BoundingRect* {.importc.} = object
-    top*, bottom*, left*, right*: int
+    top*, bottom*, left*, right*, x*, y*, width*, height*: float
 
 proc getBoundingClientRect*(e: Node): BoundingRect {.
   importcpp: "getBoundingClientRect", nodecl.}
@@ -579,8 +580,8 @@ proc clientWidth*(): int {.
 proc inViewport*(el: Node): bool =
   let rect = el.getBoundingClientRect()
   result = rect.top >= 0 and rect.left >= 0 and
-           rect.bottom <= clientHeight() and
-           rect.right <= clientWidth()
+           rect.bottom <= clientHeight().float and
+           rect.right <= clientWidth().float
 
 proc scrollTop*(e: Node): int {.importcpp: "#.scrollTop", nodecl.}
 proc offsetHeight*(e: Node): int {.importcpp: "#.offsetHeight", nodecl.}


### PR DESCRIPTION
This PR adds functionality required to do stuff like [this](https://github.com/bluenote10/KaraxExamples/tree/master/DemoTransitionGroups). Changes:

* Adds a post render callback. Transitions like these require to extract DOM information at a "post-layout" but "pre-paint" point in time, which is where the callback is called. [*]
* Added the missing `transform` property to styles.
* Added missing fields of the bounding rect object. Also changed the type to float, because the bounding rect values can be floats.
* Exposed `reqFrame` for client use (necessary for scheduling "post-paint" events).

[*] Similar to the lifecycle hooks in React, or the transition-groups in Vue.