### PR TITLE
Attempt to replace VNode inheritance by composition

### DIFF
--- a/examples/carousel/carousel.nim
+++ b/examples/carousel/carousel.nim
@@ -14,8 +14,7 @@ const ticksUntilChange = 5
 var
   images: seq[cstring] = @[cstring"a", "b", "c", "d"]
 
-proc render(x: VComponent): VNode =
-  let self = Carousel(x)
+method render(self: Carousel): VNode =
 
   proc docount() =
     dec self.cntdown
@@ -39,6 +38,7 @@ proc render(x: VComponent): VNode =
     of 2: cstring"#00ffff"
     of 3: cstring"#ffff00"
     else: cstring"red"
+
   result = buildHtml(tdiv()):
     text self.list[self.counter]
     button(onclick = onclick):
@@ -49,9 +49,10 @@ proc render(x: VComponent): VNode =
       text &self.cntdown
 
 proc carousel(): Carousel =
-  result = newComponent(Carousel, render)
-  result.list = images
-  result.cntdown = ticksUntilChange
+  Carousel(
+    list: images,
+    cntdown: ticksUntilChange,
+  )
 
 proc createDom(): VNode =
   result = buildHtml(table):

--- a/src/vdom.nim
+++ b/src/vdom.nim
@@ -119,17 +119,31 @@ type
     style*: VStyle ## the style that should be applied to the virtual node.
     dom*: Node ## the attached real DOM node. Can be 'nil' if the virtual node
                ## is not part of the virtual DOM anymore.
+    component*: VComponent
 
-  VComponent* = ref object of VNode ## The abstract class for every karax component.
-    renderImpl*: proc(self: VComponent): VNode
-    changedImpl*: proc(self: VComponent): bool
-    updatedImpl*: proc(self: VComponent)
-    onAttachImpl*: proc(self: VComponent)
-    onDetachImpl*: proc(self: VComponent)
+  VNodeRef = ref object of RootObj
+    nref: VNode
+
+  VComponent* = ref object of VNodeRef ## The abstract class for every karax component.
     version*: int         ## Update this to trigger a redraw by karax. Usually you
                           ## should call 'markDirty' instead which is an alias for
                           ## 'inc version'.
     renderedVersion*: int ## Do not touch. Used by karax.
+
+method render*(c: VComponent): VNode {.base.} = discard
+method onAttach*(c: VComponent) {.base.} = discard
+method onDetach*(c: VComponent) {.base.} = discard
+
+method changed*(c: VComponent): bool {.base.} =
+  result = c.version != c.renderedVersion
+
+method updated*(c: VComponent) {.base.} =
+  c.renderedVersion = c.version
+
+template markDirty*(c: VComponent) =
+  ## mark the component as dirty so that it is re-rendered.
+  inc c.version
+
 
 proc value*(n: VNode): cstring = n.text
 proc `value=`*(n: VNode; v: cstring) = n.text = v
@@ -149,28 +163,6 @@ proc vthunk*(name: cstring; args: varargs[VNode, vn]): VNode =
 proc dthunk*(name: cstring; args: varargs[VNode, vn]): VNode =
   VNode(kind: VNodeKind.dthunk, text: name, key: -1, kids: @args)
 
-proc defaultChangedImpl*(v: VComponent): bool =
-  ## The default implementation of 'changed'.
-  result = v.version != v.renderedVersion
-
-proc defaultUpdatedImpl*(v: VComponent) =
-  v.renderedVersion = v.version
-
-template newComponent*[T](t: typeDesc[T];
-                 render: (proc(self: VComponent): VNode) not nil,
-                 onAttach: proc(self: VComponent) = nil,
-                 onDetach: proc(self: VComponent) = nil,
-                 changed: (proc(self: VComponent): bool) = defaultChangedImpl,
-                 updated: proc(self: VComponent) = defaultUpdatedImpl): T =
-  ## Use this template to create new components.
-  T(kind: VNodeKind.component, key: -1,
-    text: cstring(astToStr(t)), renderImpl: render,
-    changedImpl: changed, updatedImpl: updated,
-    onAttachImpl: onAttach, onDetachImpl: onDetach)
-
-template markDirty*(c: VComponent) =
-  ## mark the component as dirty so that it is re-rendered.
-  inc c.version
 
 proc setAttr*(n: VNode; key: cstring; val: cstring = "") =
   if n.attrs.isNil:
@@ -190,8 +182,16 @@ proc getAttr*(n: VNode; key: cstring): cstring =
 proc len*(x: VNode): int = x.kids.len
 proc `[]`*(x: VNode; idx: int): VNode = x.kids[idx]
 proc `[]=`*(x: VNode; idx: int; y: VNode) = x.kids[idx] = y
-proc add*(parent, kid: VNode) = parent.kids.add kid
 proc newVNode*(kind: VNodeKind): VNode = VNode(kind: kind, key: -1)
+
+proc add*(parent, kid: VNode) = parent.kids.add kid
+proc add*(parent: VNode, c: VComponent) =
+  # link node <-> component
+  let n = c.render()
+  n.component = c
+  c.nref = n
+  parent.kids.add n
+
 
 proc tree*(kind: VNodeKind; kids: varargs[VNode]): VNode =
   result = newVNode(kind)


### PR DESCRIPTION
Another crazy hack :-).

After playing around with the components, I was wondering if it is possible to replace the `VNode => VComponent` inheritance by a composition. This would not only bring me closer to getting the refs problem solved, there are also some smaller issues on client side that could be improved. In particular:

* It's a bit unintuitive having to do this `render(x: VComponent)` + `self = MyComponent(x)` combined with the boilerplate to explicitly pass the render function to `newComponent`. There is also the danger of passing the wrong render function and failing type conversion.
* Many valuable field names like `text`, `kind`, or `key` are already occupied by `VNode` -- would be good to make them available to users.
* The `newComponent` initialization is not very `not nil` friendly.

To solve this I was trying to replace the inheritance by cross-linking `VNode <=> VComponent`. The client code looks a bit more straightforward to me now. I got it to a point that it compiles, but the behavior is not quite the same as before. Before I put too much thought into it: Would you be in favor of such a change?