### PR TITLE
Improved testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 nimcache/
 /tests/tester
+/.vscode
+/tests/node_modules

--- a/src/jstrutils.nim
+++ b/src/jstrutils.nim
@@ -9,6 +9,8 @@ proc contains*(a, b: cstring): bool {.importcpp: "(#.indexOf(#)>=0)", nodecl.}
 proc substr*(s: cstring; start: int): cstring {.importcpp: "substr", nodecl.}
 proc substr*(s: cstring; start, length: int): cstring {.importcpp: "substr", nodecl.}
 
+proc toLowerCase*(s: cstring): cstring {.importcpp: "(#).toLowerCase()", nodecl.}
+
 #proc len*(s: cstring): int {.importcpp: "#.length", nodecl.}
 proc `&`*(a, b: cstring): cstring {.importcpp: "(# + #)", nodecl.}
 proc toCstr*(s: int): cstring {.importcpp: "((#)+'')", nodecl.}
@@ -17,6 +19,7 @@ proc `&`*(s: bool): cstring {.importcpp: "((#)+'')", nodecl.}
 proc `&`*(s: float): cstring {.importcpp: "((#)+'')", nodecl.}
 
 proc `&`*(s: cstring): cstring {.importcpp: "(#)", nodecl.}
+proc `&=`*(a: cstring, b: cstring) {.importcpp: "(#) += (#)", nodecl.}
 
 proc isInt*(s: cstring): bool {.asmNoStackFrame.} =
   asm """

--- a/src/kdom.nim
+++ b/src/kdom.nim
@@ -129,6 +129,7 @@ type
     name*: cstring
     readOnly*: bool
     options*: seq[OptionElement]
+    tagName*: cstring
 
   # https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement
   HtmlElement* = ref object of Element

--- a/tests/jasmine.nim
+++ b/tests/jasmine.nim
@@ -1,0 +1,37 @@
+import future
+
+type
+  RegExp* = ref object
+
+  Done* = () -> void
+
+proc newRegExp*(s: cstring): RegExp {.importcpp: "new RegExp(#)".}
+
+
+proc beforeEach*(body: () -> void) {.importc.}
+proc beforeAll*(body: () -> void) {.importc.}
+proc afterEach*(body: () -> void) {.importc.}
+proc afterAll*(body: () -> void) {.importc.}
+
+proc describe*(description: cstring, body: () -> void) {.importc.}
+
+proc it*(description: cstring, body: () -> void) {.importc.}
+proc it*(description: cstring, body: (Done) -> void) {.importc.}
+
+type
+  JasmineRequireObj* {.importc.} = ref object
+    `not`* {.importc: "not".}: JasmineRequireObj
+
+proc expect*[T](x: T): JasmineRequireObj {.importc.}
+
+proc toBe*[T](e: JasmineRequireObj, x: T) {.importcpp.}
+proc toBe*[T](e: JasmineRequireObj, x: T, msg: cstring) {.importcpp.}
+
+proc toEqual*[T](e: JasmineRequireObj, x: T) {.importcpp.}
+
+proc toThrow*(e: JasmineRequireObj) {.importcpp.}
+
+proc toThrowError*(e: JasmineRequireObj, msg: cstring|RegExp) {.importcpp.}
+
+proc toThrowErrorRegExp*(e: JasmineRequireObj, msg: cstring) =
+  e.toThrowError(newRegExp(msg))

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -1,0 +1,17 @@
+module.exports = function(config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine'],
+    files: [
+      // the main test file is served by Karma
+      'nimcache/tests.js'
+    ],
+    reporters: ['spec'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['PhantomJS'], // 'Firefox'
+    singleRun: true
+  })
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "karax-unit-test-tests",
+  "version": "0.1.0",
+  "description": "Testing unit tests",
+  "scripts": {
+    "test": "npm run test:build --silent && npm run test:karma --silent",
+    "test:build": "nim js tests.nim",
+    "test:karma": "karma start karma.conf.js --singleRun",
+    "test:watch": "watch 'npm run test' . --interval=0.1"
+  },
+  "devDependencies": {
+    "jasmine": "^2.6.0",
+    "karma": "^1.7.0",
+    "karma-jasmine": "^1.1.0",
+    "karma-phantomjs-launcher": "^1.0.4",
+    "karma-spec-reporter": "0.0.31",
+    "watch": "^1.0.2"
+  }
+}

--- a/tests/test_utils.nim
+++ b/tests/test_utils.nim
@@ -1,0 +1,55 @@
+import kdom, vdom, kdom, times, karax, karaxdsl, jdict, jstrutils, parseutils, sequtils
+
+import jasmine
+
+proc installRootTag*() =
+  document.body.innerHTML &= cstring"<div id='ROOT'></div>"
+
+proc clearRootTag*() =
+  document.getElementById("ROOT").innerHTML = ""
+
+
+proc simpleTimeout*(p: proc()) =
+  discard setTimeout(p, 100)
+
+
+type
+  ExpNode* = ref object
+    tag*: cstring
+    id*: cstring
+    text*: cstring
+    # TODO: attributes etc.
+    children*: seq[ExpNode]
+
+  ExpNodes* = seq[ExpNode]
+
+proc tag*(tag: cstring; id, text: cstring = nil; children: ExpNodes = @[]): ExpNode =
+  ExpNode(
+    tag: tag,
+    id: id,
+    text: text,
+    children: children,
+  )
+
+proc expectDomToMatch*(domParent: Element, expNodes: ExpNodes) =
+  # We can't use domParent.len, only element nodes are relevant
+  var numDomElements = 0
+  for i in 0 ..< domParent.len:
+    if domParent[i].nodeType == ElementNode:
+      numDomElements += 1
+  expect(numDomElements).toBe(expNodes.len, "Number of children differs")
+
+  for i in 0 ..< expNodes.len:
+    let domElement = domParent[i]
+    let expElement = expNodes[i]
+    expect(domElement.tagName.toLowerCase()).toBe(expElement.tag.toLowerCase(), "tag doesn't match")
+    if expElement.id != nil:
+      expect(domElement.id).toBe(expElement.id, "id doesn't match")
+    if expElement.text != nil:
+      expect(domElement.value).toBe(expElement.text, "text doesn't match")
+    expectDomToMatch(domElement, expElement.children)
+
+proc expectDomToMatch*(elementId: cstring, expNodes: ExpNodes) =
+  let element = document.getElementById(elementId)
+  expectDomToMatch(element, expNodes)
+

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -3,6 +3,7 @@
 import os
 
 proc exec(cmd: string) =
+  echo "Running: ", cmd
   if os.execShellCmd(cmd) != 0:
     quit "command failed " & cmd
 
@@ -13,5 +14,9 @@ proc main =
   exec("nim js examples/scrollapp/scrollapp.nim")
   exec("nim js examples/mediaplayer/playerapp.nim")
   exec("nim js examples/carousel/carousel.nim")
+
+  setCurrentDir("tests")
+  exec("npm install")
+  exec("npm test")
 
 main()

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1,0 +1,132 @@
+import kdom, vdom, times, karax, karaxdsl, jdict, jstrutils, parseutils, sequtils
+import future
+import test_utils
+import jasmine
+
+installRootTag()
+
+
+describe("Dom diffing of simple seq model"):
+
+  proc initValues(): auto = @[0, 1, 2, 3, 4, 5].map(x => cstring($x))
+
+  var entries = initValues()
+
+  proc createEntry(id: int): VNode =
+    result = buildHtml():
+      button(id = $id):
+        text $id
+
+  proc createDom(): VNode =
+    result = buildHtml(tdiv()):
+      ul(id="ul"):
+        for e in entries:
+          createEntry(parseInt(e))
+
+  beforeAll() do ():
+    clearRootTag()
+    setRenderer createDom
+
+  beforeEach() do ():
+    entries = initValues()
+
+  it("should match after intialization values") do (done: Done):
+
+    simpleTimeout() do ():
+      # kout(document.getElementById("ROOT").innerHTML)
+      expectDomToMatch("ROOT", @[
+        tag("ul", children = @[
+          tag("button", id="0"),
+          tag("button", id="1"),
+          tag("button", id="2"),
+          tag("button", id="3"),
+          tag("button", id="4"),
+          tag("button", id="5"),
+        ])
+      ])
+      done()
+
+  it("should handle single insertion") do (done: Done):
+
+    entries.insert(cstring("7"), 5)
+    kxi.redraw()
+
+    simpleTimeout() do ():
+      # kout(document.getElementById("ROOT").innerHTML)
+      expectDomToMatch("ROOT", @[
+        tag("ul", children = @[
+          tag("button", id="0"),
+          tag("button", id="1"),
+          tag("button", id="2"),
+          tag("button", id="3"),
+          tag("button", id="4"),
+          tag("button", id="7"),
+          tag("button", id="5"),
+        ])
+      ])
+      done()
+
+  it("should handle double insertion") do (done: Done):
+
+    entries.insert(cstring("7"), 5)
+    entries.insert(cstring("8"), 0)
+    kxi.redraw()
+
+    simpleTimeout() do ():
+      # kout(document.getElementById("ROOT").innerHTML)
+      expectDomToMatch("ROOT", @[
+        tag("ul", children = @[
+          tag("button", id="8"),
+          tag("button", id="0"),
+          tag("button", id="1"),
+          tag("button", id="2"),
+          tag("button", id="3"),
+          tag("button", id="4"),
+          tag("button", id="7"),
+          tag("button", id="5"),
+        ])
+      ])
+      done()
+
+  it("should handle replacing the seq") do (done: Done):
+
+    entries = @[2, 3, 4, 1].map(x => cstring($x))
+    kxi.redraw()
+
+    simpleTimeout() do ():
+      # kout(document.getElementById("ROOT").innerHTML)
+      expectDomToMatch("ROOT", @[
+        tag("ul", children = @[
+          tag("button", id="2"),
+          tag("button", id="3"),
+          tag("button", id="4"),
+          tag("button", id="1"),
+        ])
+      ])
+      done()
+
+  it("should handle a single-element seq") do (done: Done):
+
+    entries = @[cstring"42"]
+    kxi.redraw()
+
+    simpleTimeout() do ():
+      # kout(document.getElementById("ROOT").innerHTML)
+      expectDomToMatch("ROOT", @[
+        tag("ul", children = @[
+          tag("button", id="42"),
+        ])
+      ])
+      done()
+
+  it("should handle an empty seq") do (done: Done):
+
+    entries = @[]
+    kxi.redraw()
+
+    simpleTimeout() do ():
+      # kout(document.getElementById("ROOT").innerHTML)
+      expectDomToMatch("ROOT", @[
+        tag("ul")
+      ])
+      done()


### PR DESCRIPTION
Some improvements on testing to make it easier to cover all sorts of edge cases in the DOM diffing. 

The approach I'm taking here is to use karma + jasmine, run by npm scripts. This has the benefit that we can run automated tests across different browsers (i.e. real DOM + events), but also in headless mode via PhantomJS on Travis. At first I considered writing pure Nim test suites, but this would require quite some work with the test runner integration and handling of async tests. Porting the basic functions of jasmine was really easy and works pretty well. It should be straightforward to extend this to also simulate e.g. button clicks, if we really want to test dynamic behavior (but I think most things could be covered with how it is now already). So far I have just reproduced (more or less) what was in `diffDomTests.nim` before.

With node/npm installed, running the tests should simply work by:

    npm install
    npm test

To run in a browser in addition to headless: `npm install karma-firefox-launcher --save-dev` and add `Firefox` to the `browsers` in `karma.conf.js`.

The bindings of jasmine are not complete, I have just covered what was needed so far. The DSL for validating the DOM is also not yet complete, and could be improved. But it already produces some nice output: https://travis-ci.org/bluenote10/karax#L1289
