### PR TITLE
Fixing not nil issue.

### DIFF
--- a/karax/karax.nim
+++ b/karax/karax.nim
@@ -1,4 +1,5 @@
 ## Karax -- Single page applications for Nim.
+{.experimental: "notnil".}
 
 import kdom, vdom, jstrutils, compact, jdict, vstyles
 


### PR DESCRIPTION
Nim verison - 
```
Nim Compiler Version 0.18.1 [MacOSX: amd64]
Compiled at 2018-05-13 11:01:23
Copyright (c) 2006-2018 by Andreas Rumpf

active boot switches: -d:release
```

Error -
```
karax/karax.nim(31, 21) Error: enable the 'not nil' annotation with {.experimental: "notnil".}
```

Diff -
```
diff --git a/karax/karax.nim b/karax/karax.nim
index ca6e50b..19a7dfb 100644
--- a/karax/karax.nim
+++ b/karax/karax.nim
@@ -1,5 +1,4 @@
 ## Karax -- Single page applications for Nim.
-{.experimental: "notnil".}
 
 import kdom, vdom, jstrutils, compact, jdict, vstyles
 ```
