### PR TITLE
Add support for rendering styles to string

### DIFF
--- a/karax/vdom.nim
+++ b/karax/vdom.nim
@@ -8,7 +8,7 @@ else:
     Node* = ref object
 
 import macros, vstyles, kbase
-from strutils import toUpperAscii
+from strutils import toUpperAscii, toLowerAscii, tokenize
 
 type
   VNodeKind* {.pure.} = enum
@@ -399,7 +399,17 @@ proc add*(result: var string, n: VNode, indent = 0, indWidth = 2) =
       result.add("=\"")
       result.addEscapedAttr(v)
       result.add('"')
-    # XXX add style to string
+    if n.style != nil:
+      result.add " style=\""
+      for k, v in pairs(n.style):
+        if v.len == 0: continue
+        for t in tokenize($k, seps={'A' .. 'Z'}):
+          if t.isSep: result.add '-'
+          result.add toLowerAscii(t.token)
+        result.add ": "
+        result.add v
+        result.add "; "
+      result.add('"')
     if n.len > 0:
       result.add('>')
       if n.len > 1:


### PR DESCRIPTION
I went with the most consistent method (relative to the code around it) I could come up with, while keeping the code simple and efficient. I considered using regex, but found the `tokenize` function which solves this problem quite nicely. It works because all style enums use camelCasing, so `marginTop` -> `margin-top`.
Minor cosmetic nitpick is there will always be an extra space at the end (`style="margin-top: 1em; "`), but I couldn't come up with a short solution that doesn't use a temporary variable, stripping `result`, or keeping an index variable.