### PR TITLE
Fix tag termination for elements with no children

### DIFF
--- a/karax/vdom.nim
+++ b/karax/vdom.nim
@@ -425,7 +425,10 @@ proc add*(result: var string, n: VNode, indent = 0, indWidth = 2) =
       result.add(kind)
       result.add(">")
     else:
-      result.add(" />")
+      result.add(">")
+      result.add("</")
+      result.add(kind)
+      result.add(">")
 
 
 proc `$`*(n: VNode): kstring =


### PR DESCRIPTION
Ending elements with ` />` does not actually terminate them. At least not according to Blink/webkit. 

```html
<div>
  <video />
  <p>label</p>
</div>
```

Gets rendered like this in Chromium:
```html
<div>
  <video>
    <p>label</p>
  </video>
</div>
```