### PR TITLE
fix #121 fix #56 

### DIFF
--- a/karax/karax.nim
+++ b/karax/karax.nim
@@ -376,7 +376,10 @@ proc applyPatch(kxi: KaraxInstance) =
       if p.parent == nil:
         replaceById(kxi.rootId, nn)
       else:
-        p.parent.replaceChild(nn, p.current)
+        if p.current.parentNode == p.parent:
+          p.parent.replaceChild(nn, p.current)
+        else: # fix #121
+          p.parent.appendChild(nn)
     of pkSame:
       moveDom(p.newNode, p.oldNode)
     of pkRemove:


### PR DESCRIPTION
/cc @araq this seems to:
* fix #121 (as well as my original problem from which this was a reduced case)
also works with reordering eg: `velements = velements[2..^1]` => `velements = @[velements[2], velements[4], velements[3]]`
* fix #56 (in particular https://github.com/pragmagic/karax/issues/56#issuecomment-531099826 which more obviously exhibits the bug)
