### PR TITLE
make vstyles.setAttr kstring overload public

### DIFF
--- a/karax/vstyles.nim
+++ b/karax/vstyles.nim
@@ -234,7 +234,7 @@ proc eq*(a, b: VStyle): bool =
     if a[i] != b[i]: return false
   return true
 
-proc setAttr(s: VStyle; a, value: kstring) {.noSideEffect.} =
+proc setAttr*(s: VStyle; a, value: kstring) {.noSideEffect.} =
   var i = 0
   while i < s.len:
     if s[i] == a:


### PR DESCRIPTION
example use case: allow client code to write this:
```nim
proc toCss*(a: string): VStyle =
  #[
  can be simpler than this when porting existing code to karax:
  {cssFloat: "left", borderColor:"red"}
  "float:left borderColor:red"
  style(StyleAttr.color, col) => "color:red".toCss
  note: this doesn't seem related: https://github.com/pragmagic/karax/pull/102
  ]#
  # result = VStyle()
  result = newJSeq[cstring]()
  for ai in a.split(";"):
    var ai = ai.strip
    if ai.len == 0: continue
    let aj = ai.strip.split(":", maxsplit=1)
    # result.setAttr(aj[0].parseEnum[:StyleAttr], aj[1]) # this would often not work, and is roundabout / inefficient
    result.setAttr(aj[0], aj[1])
```
(which could later be part of karax), to use a string directly instead of an enum, and can be simpler than this when porting existing code to karax.
