### PR TITLE
close #6

### DIFF
--- a/karax.nimble
+++ b/karax.nimble
@@ -7,7 +7,7 @@ license       = "MIT"
 
 # Dependencies
 
-requires "nim >= 0.16.1"
+requires "nim >= 0.18.0"
 requires "ws"
 requires "dotenv"
 skipDirs = @["examples", "experiments", "tests"]


### PR DESCRIPTION
close #6

I could've also changed it to >= 1.0.0 but at least this example shows we need >= 0.18

choosenim 0.17.0
karun -r examples/scrollapp/scrollapp.nim
karax/karax/vdom.nim(48, 22) Error: undeclared identifier: 'area'

works with 0.18.0
