### PR TITLE
add toCss: allows tdiv(style = "font-style: oblique; color: pink".toCss)

### DIFF
--- a/examples/hellostyle.nim
+++ b/examples/hellostyle.nim
@@ -1,0 +1,17 @@
+include karax / prelude
+import karax / vstyles
+
+proc createDom(): VNode =
+  result = buildHtml(tdiv):
+    tdiv(style = style(StyleAttr.color, "red".cstring)):
+      text "red"
+    tdiv(style = style(StyleAttr.color, "blue")):
+      text "blue"
+    # explicit `kstring` required for varargs overload
+    tdiv(style = style((fontStyle, "italic".kstring), (color, "orange".kstring))):
+      text "italic orange"
+    # can use a string directly
+    tdiv(style = "font-style: oblique; color: pink".toCss):
+      text "oblique pink"
+
+setRenderer createDom

--- a/karax/vstyles.nim
+++ b/karax/vstyles.nim
@@ -303,7 +303,11 @@ proc toCss*(a: string): VStyle =
   tdiv(style = style((fontStyle, "italic".kstring), (color, "orange".kstring))): discard
   tdiv(style = "font-style: oblique; color: pink".toCss): discard
   ]##
-  result = newJSeq[cstring]()
+  when defined(js):
+    result = newJSeq[cstring]()
+  else:
+    new(result)
+    result[] = @[]
   for ai in a.split(";"):
     var ai = ai.strip
     if ai.len == 0: continue

--- a/karax/vstyles.nim
+++ b/karax/vstyles.nim
@@ -1,5 +1,9 @@
+##[
+see examples/hellostyle.nim
+]##
 
-import macros, kbase
+import std/[macros, strutils]
+import kbase
 
 when defined(js):
   import kdom, jdict
@@ -291,6 +295,20 @@ proc style*(a: StyleAttr; val: kstring): VStyle {.noSideEffect.} =
     new(result)
     result[] = @[]
   result.setAttr a, val
+
+proc toCss*(a: string): VStyle =
+  ##[
+  See example in hellostyle.nim
+  Allows passing a css string directly, eg:
+  tdiv(style = style((fontStyle, "italic".kstring), (color, "orange".kstring))): discard
+  tdiv(style = "font-style: oblique; color: pink".toCss): discard
+  ]##
+  result = newJSeq[cstring]()
+  for ai in a.split(";"):
+    var ai = ai.strip
+    if ai.len == 0: continue
+    let aj = ai.strip.split(":", maxsplit=1)
+    result.setAttr(aj[0], aj[1])
 
 when defined(js):
   proc setStyle(d: Style; key, val: cstring) {.importcpp: "#[#] = #", noSideEffect.}


### PR DESCRIPTION
see ` karun -r $nim_D/karax/examples/hellostyle.nim`

the last commit makes sure toCss also works with nim c, eg in following example:

~~(note: see followup PR to fix pre-existing bug to make this work, see https://github.com/pragmagic/karax/issues/153 EDIT: fixed in recent PR)~~
`nim r main`
```nim
when true:
  import karax / [karaxdsl, vdom, vstyles]
  let node = buildHtml(tdiv):
    let myStyle = "width: 25%; border: 1px".toCss
    tdiv(style = myStyle):
       text ""

  echo $node
```

/cc @araq please let me know if you can think of a way to allow writing directly
```nim
tdiv(style = "width: 25%; border: 1px"): discard
# instead of
tdiv(style = "width: 25%; border: 1px".toCss): discard
```
without resorting to `converter`, otherwise this is ready for review