### PR TITLE
fix #153

### DIFF
--- a/karax/vdom.nim
+++ b/karax/vdom.nim
@@ -303,6 +303,12 @@ proc sameAttrs*(a, b: VNode): bool =
 proc addEventListener*(n: VNode; event: EventKind; handler: EventHandler) =
   n.events.add((event, handler, nil))
 
+when kstring is cstring:
+  proc len(a: kstring): int =
+    # xxx: maybe move where kstring is defined
+    # without this, `n.field.len` fails on js (non web) platform
+    if a == nil: 0 else: a.len
+
 template toStringAttr(field) =
   if n.field.len > 0:
     result.add " " & astToStr(field) & " = " & $n.field

--- a/karax/vstyles.nim
+++ b/karax/vstyles.nim
@@ -235,6 +235,9 @@ proc eq*(a, b: VStyle): bool =
   return true
 
 proc setAttr*(s: VStyle; a, value: kstring) {.noSideEffect.} =
+  ## inserts (a, value) in sorted order of key `a`
+  # worst case quadratic complexity (if given styles in reverse order), hopefully
+  # not a concern assuming small cardinal
   var i = 0
   while i < s.len:
     if s[i] == a:
@@ -243,8 +246,8 @@ proc setAttr*(s: VStyle; a, value: kstring) {.noSideEffect.} =
     elif s[i] > a:
       s.add ""
       s.add ""
-      # insertion point here:
-      for j in countdown(s.len-1, i, 2):
+      # insertion point here, shift all remaining pairs by 2 indexes
+      for j in countdown(s.len-1, i+3, 2):
         s[j] = s[j-2]
         s[j-1] = s[j-3]
       s[i] = a


### PR DESCRIPTION
fix #153

(2 distinct bugs fixed, see below)

```nim
when true:
  import karax / [karaxdsl, vdom, vstyles]
  import karax/kbase
  let node = buildHtml(tdiv):
    let myStyle = style((StyleAttr.width, "25%".kstring),
                        (StyleAttr.border, "1px".kstring))
    tdiv(style = myStyle):
       text ""

  echo $node
```

before PR:

```
nim c -r main
/Users/timothee/git_clone/nim/karax/karax/vstyles.nim(248) setAttr
/Users/timothee/git_clone/nim/Nim_devel/lib/system/fatal.nim(49) sysFatal
Error: unhandled exception: index -1 not in 0 .. 3 [IndexDefect]


nim js -r main
/Users/timothee/git_clone/nim/timn/tests/karax/t1.js:4985
    if ((0 < (n_22050054.id).length)) {
                             ^
TypeError: Cannot read property 'length' of null
    at toString_22050052 (/Users/timothee/git_clone/nim/timn/tests/karax/t1.js:4985:30)
    at HEX24_22110020 (/Users/timothee/git_clone/nim/timn/tests/karax/t1.js:5103:5)
    at Object.<anonymous> (/Users/timothee/git_clone/nim/timn/tests/karax/t1.js:5128:22)

karun -r main
Uncaught TypeError: Cannot read property 'length' of null
    at toString_22050052 (app.js:4985)
    at HEX24_22110020 (app.js:5103)
    at app.js:5128
```

after PR:
```
nim c -r main
<div><div style="border: 1px; width: 25%; "></div></div>

nim js -r main
<div>
  
<div>
    
<#text>
    
</#text>  
</div>
</div>

karun -r main
=> ditto in browser console
```

the fact that `nim c` differs from `nim js` is some other bug, perhaps
