### PR TITLE
add svg tags symbol, defs, use

### DIFF
--- a/karax/vdom.nim
+++ b/karax/vdom.nim
@@ -35,7 +35,7 @@ type
     mark, ruby, rt, rp, bdi, dbo, span, br, wbr,
     ins, del, img, iframe, embed, `object` = "object",
     param, video, audio, source, track, canvas, map,
-    area, svg, math, path, circle
+    area, svg, symbol, defs, use, math, path, circle,
 
     table, caption, colgroup, col, tbody, thead,
     tfoot, tr, td, th,
@@ -101,9 +101,9 @@ type
     ontransitionend,
     ontransitionrun,
     ontransitionstart,
-    
+
     onwheel # fires when the user rotates a wheel button on a pointing device.
-    
+
 macro buildLookupTables(): untyped =
   var a = newTree(nnkBracket)
   for i in low(VNodeKind)..high(VNodeKind):


### PR DESCRIPTION
These tags are used in conjunction to be able to [reference](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use) svg elements from other parts of the document. Example:

```nim
include karax/prelude
import karax/vstyles

proc createDom(): VNode =
  result = buildHtml(tdiv):
    button:
      svg:
        use(href = "#myicon")
    svg(style = style(StyleAttr.display, "hidden".cstring), xmlns = "http://www.w3.org/2000/svg"):
      defs:
        symbol(id = "myicon" viewBox = "0 0 24 24"):
          ...
```