### PR TITLE
Make 'karun -w -r ...' do watching for more than one iteration

### DIFF
--- a/karax/tools/karun.nim
+++ b/karax/tools/karun.nim
@@ -59,7 +59,7 @@ proc build(rest: string, selectedCss: string, run: bool, watch: bool) =
   else:
     exec cmd
   let dest = "app" & ".html"
-  let script = if run and watch: websocket else: ""
+  let script = if watch: websocket else: ""
   writeFile(dest, html % ["app", selectedCss, script])
   if run: openDefaultBrowser("http://localhost:8080")
 


### PR DESCRIPTION
Currently if you run `karun -w -r thing.nim` it will refresh the browser via websocket the first time `thing.nim` is changed, but not for subsequent changes.