### PR TITLE
Added hgroup tag

### DIFF
--- a/karax/vdom.nim
+++ b/karax/vdom.nim
@@ -19,7 +19,7 @@ type
     html, head, title, base, link, meta, style,
     script, noscript,
     body, section, nav, article, aside,
-    h1, h2, h3, h4, h5, h6,
+    h1, h2, h3, h4, h5, h6, hgroup,
     header, footer, address, main,
 
     p, hr, pre, blockquote, ol, ul, li,


### PR DESCRIPTION
While it isn't a part of the HTML5 spec anymore, every single browser (including IE9) has support for it. See https://caniuse.com/?search=hgroup

Not sure if there is an easy way to use a custom tag in Karax, glanced through the implementation but didn't notice anything. The closest option we have is `verbatim`